### PR TITLE
ClassPathScanner is more robust now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.avaje</groupId>
       <artifactId>avaje-classpath-scanner-api</artifactId>
-      <version>2.1</version>
+      <version>2.2-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/avaje/classpath/scanner/internal/scanner/classpath/ClassPathScanner.java
+++ b/src/main/java/org/avaje/classpath/scanner/internal/scanner/classpath/ClassPathScanner.java
@@ -106,10 +106,16 @@ public class ClassPathScanner implements ResourceAndClassScanner {
       LOG.debug("scanning for classes at {} found {} resources to check", location, resourceNames.size());
       for (String resourceName : resourceNames) {
         String className = toClassName(resourceName);
-        Class<?> clazz = classLoader.loadClass(className);
-        if (predicate.isMatch(clazz)) {
-          classes.add(clazz);
-          LOG.trace("... matched class: {} ", className);
+        try {
+          Class<?> clazz = classLoader.loadClass(className);
+          if (predicate.isMatch(clazz)) {
+            classes.add(clazz);
+            LOG.trace("... matched class: {} ", className);
+          }
+        } catch (NoClassDefFoundError err) {
+          // This hapens on class that inherits from an other class which are no longer in the classpath
+          // e.g. "public class MyTestRunner extends BlockJUnit4ClassRunner" and junit was in scope "provided" 
+          LOG.debug("... class {} could not be loaded and will be ignored.",  className, err);	
         }
       }
 


### PR DESCRIPTION
It ignores "NoClassDefFoundErros" that may occur if dependent classes are not on classpath. (or not yet available in java 7)
Bumped also avaje-classpath-scanner-api to 2.2-SNAPSHOT so that tests will pass on Windows-machine
