### PR TITLE
Fix typo in `AndriodContextHolder`

### DIFF
--- a/src/main/java/io/avaje/classpath/scanner/core/AndroidContextHolder.java
+++ b/src/main/java/io/avaje/classpath/scanner/core/AndroidContextHolder.java
@@ -24,8 +24,8 @@ import android.content.Context;
  *     You can set this within an activity using ContextHolder.setContext(this);
  * </p>
  */
-public class AndriodContextHolder {
-  private AndriodContextHolder() {
+public class AndroidContextHolder {
+  private AndroidContextHolder() {
   }
 
   /**
@@ -44,6 +44,6 @@ public class AndriodContextHolder {
    * @param context The Android context to use to be able to scan assets and classes for migrations.
    */
   public static void setContext(Context context) {
-    AndriodContextHolder.context = context;
+    AndroidContextHolder.context = context;
   }
 }

--- a/src/main/java/io/avaje/classpath/scanner/internal/scanner/classpath/android/AndroidScanner.java
+++ b/src/main/java/io/avaje/classpath/scanner/internal/scanner/classpath/android/AndroidScanner.java
@@ -43,7 +43,7 @@ public class AndroidScanner implements ResourceAndClassScanner {
     this.classLoader = (PathClassLoader) classLoader;
     context = AndroidContextHolder.getContext();
     if (context == null) {
-      throw new IllegalStateException("Unable to create scanner. Within an activity fix this with io.avaje.classpath.scanner.android.ContextHolder.setContext(this);");
+      throw new IllegalStateException("Unable to create scanner. Within an activity fix this with io.avaje.classpath.scanner.android.AndroidContextHolder.setContext(this);");
     }
   }
 

--- a/src/main/java/io/avaje/classpath/scanner/internal/scanner/classpath/android/AndroidScanner.java
+++ b/src/main/java/io/avaje/classpath/scanner/internal/scanner/classpath/android/AndroidScanner.java
@@ -19,7 +19,7 @@ import android.content.Context;
 import dalvik.system.DexFile;
 import dalvik.system.PathClassLoader;
 import io.avaje.classpath.scanner.Resource;
-import io.avaje.classpath.scanner.core.AndriodContextHolder;
+import io.avaje.classpath.scanner.core.AndroidContextHolder;
 import io.avaje.classpath.scanner.core.Location;
 import io.avaje.classpath.scanner.internal.ResourceAndClassScanner;
 
@@ -41,7 +41,7 @@ public class AndroidScanner implements ResourceAndClassScanner {
 
   public AndroidScanner(ClassLoader classLoader) {
     this.classLoader = (PathClassLoader) classLoader;
-    context = AndriodContextHolder.getContext();
+    context = AndroidContextHolder.getContext();
     if (context == null) {
       throw new IllegalStateException("Unable to create scanner. Within an activity fix this with io.avaje.classpath.scanner.android.ContextHolder.setContext(this);");
     }


### PR DESCRIPTION
Randomly spotted, said in Discord [[29 Aug 2025](https://discord.com/channels/1074074312421683250/1074074312874672181/1411034836524859534)]

How much should I bet this repository isn't being used anymore anyway?

EDIT — This is in the `.core` package and grep of [ebean](https://github.com/ebean-orm/ebean) & [ebean-migration](https://github.com/ebean-orm/ebean-migration) shows 0 usage.
If you come back and want to merge it, do not take my word for it at all, but it looks safe.

Signed-off-by: Mahied Maruf <contact@mechite.com>